### PR TITLE
Fix: API key header forwarding bug

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -124,7 +124,7 @@ func (ah *AutocacheHandler) handleNonStreamingRequest(w http.ResponseWriter, r *
 
 	// Extract API key
 	apiKey := ah.getAPIKey(r)
-	headers := client.CreateHeadersMap(r.Header, apiKey)
+	headers := client.CreateHeadersMap(r.Header, apiKey, ah.logger)
 
 	// Forward the request
 	resp, err := ah.proxyClient.ForwardRequest(req, headers)
@@ -187,7 +187,7 @@ func (ah *AutocacheHandler) handleStreamingRequest(w http.ResponseWriter, r *htt
 
 	// Extract API key
 	apiKey := ah.getAPIKey(r)
-	headers := client.CreateHeadersMap(r.Header, apiKey)
+	headers := client.CreateHeadersMap(r.Header, apiKey, ah.logger)
 
 	// Forward the streaming request
 	err = ah.proxyClient.ForwardStreamingRequest(req, headers, w)
@@ -214,7 +214,7 @@ func (ah *AutocacheHandler) forwardWithoutCaching(w http.ResponseWriter, r *http
 	w.Header().Set("X-Autocache-Injected", "false")
 
 	apiKey := ah.getAPIKey(r)
-	headers := client.CreateHeadersMap(r.Header, apiKey)
+	headers := client.CreateHeadersMap(r.Header, apiKey, ah.logger)
 
 	if client.IsStreamingRequest(req) {
 		err := ah.proxyClient.ForwardStreamingRequest(req, headers, w)
@@ -302,7 +302,7 @@ func (ah *AutocacheHandler) shouldBypassCaching(r *http.Request) bool {
 // getAPIKey extracts API key from request or config
 func (ah *AutocacheHandler) getAPIKey(r *http.Request) string {
 	// First try to get from request headers
-	apiKey := client.ExtractAPIKey(r.Header)
+	apiKey := client.ExtractAPIKey(r.Header, ah.logger)
 	if apiKey != "" {
 		return apiKey
 	}


### PR DESCRIPTION
## Summary
Fixes a critical bug where API keys passed via request headers were not being properly forwarded to the Anthropic API.

## Problem
When running autocache **without** `ANTHROPIC_API_KEY` environment variable and passing the API key via request headers (e.g., `x-api-key`, `X-Api-Key`), the proxy would fail with authentication errors:
```
{"error":{"type":"authentication_error","message":"x-api-key header is required"}}
```

This breaks the multi-tenant use case described in the README where different requests use different API keys.

## Root Cause
**Case-sensitivity bug**: When HTTP headers like `X-Api-Key` were received, they were copied to the forwarding headers map preserving their casing, then a new lowercase `x-api-key` header was added. This resulted in **duplicate/conflicting headers** being sent to Anthropic.

Example of what was being sent:
- `X-Api-Key: sk-ant-...` (from original request)
- `x-api-key: sk-ant-...` (added by SetupAuthHeader)

## Solution
- Remove all variations of existing auth headers (case-insensitive check) before adding the normalized `x-api-key` header
- Add debug logging to trace API key extraction and header setup for easier troubleshooting
- Add `maskAPIKey()` helper function for secure logging (shows first 10 chars only)

## Changes
- `internal/client/anthropic.go`:
  - Update `ExtractAPIKey()` to accept logger and add debug logging
  - Update `SetupAuthHeader()` to remove existing auth headers case-insensitively
  - Update `CreateHeadersMap()` to accept logger
  - Add `maskAPIKey()` helper function
  - Add debug logging throughout header forwarding flow

- `internal/server/handler.go`:
  - Update calls to `ExtractAPIKey()` and `CreateHeadersMap()` with logger parameter

## Testing
- ✅ All unit tests pass
- ✅ golangci-lint clean
- ✅ Manually tested with API key in headers (no env var)
- ✅ Manually tested with API key in env var (still works)
- ✅ Tested case variations: `x-api-key`, `X-Api-Key`, `X-API-KEY`

## Impact
- **Severity**: High - breaks multi-tenant scenarios
- **Scope**: Only affects users passing API key via headers (not environment variable)
- **Backward compatibility**: Fully backward compatible

## Release Notes
Should be included in v1.0.1 patch release.