### PR TITLE
Fix system prompt caching for string format

### DIFF
--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -59,10 +59,18 @@ func createMockAnthropicServer() *httptest.Server {
 		hasCacheControl := false
 		cacheTokens := 0
 
-		// Check system message for cache control
+		// Check system message for cache control (string format)
 		if req.System != "" {
 			cacheTokens += 500 // Mock cached system tokens
 			hasCacheControl = true
+		}
+
+		// Check system blocks for cache control (array format)
+		for _, block := range req.SystemBlocks {
+			if block.CacheControl != nil {
+				cacheTokens += 500 // Mock cached system tokens
+				hasCacheControl = true
+			}
 		}
 
 		// Check tools for cache control

--- a/internal/types/models_test.go
+++ b/internal/types/models_test.go
@@ -234,3 +234,266 @@ func TestMessageMarshalJSON_OutputsArray(t *testing.T) {
 		t.Errorf("Expected 1 content block in output, got %d", len(content))
 	}
 }
+
+// TestAnthropicRequest_MarshalJSON_SystemString tests that system string is preserved
+func TestAnthropicRequest_MarshalJSON_SystemString(t *testing.T) {
+	req := AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		System:    "You are a helpful assistant",
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Unmarshal to check structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// System should be a string
+	system, ok := result["system"].(string)
+	if !ok {
+		t.Errorf("Expected system to be a string, got %T", result["system"])
+	}
+
+	if system != "You are a helpful assistant" {
+		t.Errorf("Expected system text, got %s", system)
+	}
+}
+
+// TestAnthropicRequest_MarshalJSON_SystemBlocks tests that SystemBlocks are serialized as system array
+func TestAnthropicRequest_MarshalJSON_SystemBlocks(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		SystemBlocks: []ContentBlock{
+			{
+				Type: "text",
+				Text: "You are a helpful assistant",
+				CacheControl: &CacheControl{
+					Type: "ephemeral",
+					TTL:  "1h",
+				},
+			},
+		},
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Unmarshal to check structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// System should be an array (not a string)
+	systemArray, ok := result["system"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected system to be an array when SystemBlocks is set, got %T", result["system"])
+	}
+
+	if len(systemArray) != 1 {
+		t.Fatalf("Expected 1 system block, got %d", len(systemArray))
+	}
+
+	// Check the first block
+	block, ok := systemArray[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected system block to be an object, got %T", systemArray[0])
+	}
+
+	if block["type"] != "text" {
+		t.Errorf("Expected type 'text', got %v", block["type"])
+	}
+
+	if block["text"] != "You are a helpful assistant" {
+		t.Errorf("Expected text 'You are a helpful assistant', got %v", block["text"])
+	}
+
+	// Check cache_control exists
+	cacheControl, ok := block["cache_control"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected cache_control to exist, got %T", block["cache_control"])
+	}
+
+	if cacheControl["type"] != "ephemeral" {
+		t.Errorf("Expected cache_control type 'ephemeral', got %v", cacheControl["type"])
+	}
+
+	if cacheControl["ttl"] != "1h" {
+		t.Errorf("Expected cache_control ttl '1h', got %v", cacheControl["ttl"])
+	}
+}
+
+// TestAnthropicRequest_MarshalJSON_SystemBlocksPriority tests SystemBlocks takes priority over System
+func TestAnthropicRequest_MarshalJSON_SystemBlocksPriority(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		System:    "This should be ignored",
+		SystemBlocks: []ContentBlock{
+			{
+				Type: "text",
+				Text: "This should be used",
+			},
+		},
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Unmarshal to check structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// System should be an array (SystemBlocks takes priority)
+	systemArray, ok := result["system"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected system to be an array when SystemBlocks is set, got %T", result["system"])
+	}
+
+	block, ok := systemArray[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected system block to be an object, got %T", systemArray[0])
+	}
+
+	if block["text"] != "This should be used" {
+		t.Errorf("Expected SystemBlocks to take priority, got text: %v", block["text"])
+	}
+}
+
+// TestAnthropicRequest_UnmarshalJSON_SystemString tests unmarshaling system as string
+func TestAnthropicRequest_UnmarshalJSON_SystemString(t *testing.T) {
+	jsonData := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"max_tokens": 100,
+		"system": "You are a helpful assistant",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+	}`)
+
+	var req AnthropicRequest
+	err := json.Unmarshal(jsonData, &req)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if req.System != "You are a helpful assistant" {
+		t.Errorf("Expected System string, got %s", req.System)
+	}
+
+	if len(req.SystemBlocks) != 0 {
+		t.Error("SystemBlocks should be empty when system is a string")
+	}
+}
+
+// TestAnthropicRequest_UnmarshalJSON_SystemBlocks tests unmarshaling system as array
+func TestAnthropicRequest_UnmarshalJSON_SystemBlocks(t *testing.T) {
+	jsonData := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"max_tokens": 100,
+		"system": [
+			{
+				"type": "text",
+				"text": "You are a helpful assistant",
+				"cache_control": {"type": "ephemeral", "ttl": "1h"}
+			}
+		],
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+	}`)
+
+	var req AnthropicRequest
+	err := json.Unmarshal(jsonData, &req)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if req.System != "" {
+		t.Error("System string should be empty when system is an array")
+	}
+
+	if len(req.SystemBlocks) != 1 {
+		t.Fatalf("Expected 1 SystemBlock, got %d", len(req.SystemBlocks))
+	}
+
+	if req.SystemBlocks[0].Text != "You are a helpful assistant" {
+		t.Errorf("Expected text in SystemBlock, got %s", req.SystemBlocks[0].Text)
+	}
+
+	if req.SystemBlocks[0].CacheControl == nil {
+		t.Fatal("Expected cache_control in SystemBlock")
+	}
+
+	if req.SystemBlocks[0].CacheControl.Type != "ephemeral" {
+		t.Errorf("Expected cache_control type 'ephemeral', got %s", req.SystemBlocks[0].CacheControl.Type)
+	}
+}
+
+// TestAnthropicRequest_RoundTrip tests marshal -> unmarshal round trip
+func TestAnthropicRequest_RoundTrip(t *testing.T) {
+	original := &AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		SystemBlocks: []ContentBlock{
+			{
+				Type: "text",
+				Text: "System prompt",
+				CacheControl: &CacheControl{
+					Type: "ephemeral",
+					TTL:  "1h",
+				},
+			},
+		},
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	// Marshal
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	// Unmarshal
+	var decoded AnthropicRequest
+	err = json.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	// Verify
+	if len(decoded.SystemBlocks) != 1 {
+		t.Fatalf("Expected 1 SystemBlock after round trip, got %d", len(decoded.SystemBlocks))
+	}
+
+	if decoded.SystemBlocks[0].Text != "System prompt" {
+		t.Errorf("Text mismatch after round trip: got %s", decoded.SystemBlocks[0].Text)
+	}
+
+	if decoded.SystemBlocks[0].CacheControl == nil {
+		t.Fatal("CacheControl lost after round trip")
+	}
+}


### PR DESCRIPTION
## Fixes

Closes #4

## Problem

System prompts using the simple string format were not being cached, even when exceeding the 1024-token minimum threshold. Users reported that `usage.cache_creation_input_tokens` and `usage.cache_read_input_tokens` were always `0`, despite having large system prompts (>1024 tokens).

### Root Cause

The Anthropic API supports two formats for system prompts:
1. **String format**: `"system": "text here"` (commonly used)
2. **Blocks format**: `"system": [{"type": "text", "text": "..."}]`

Cache control can only be applied to the **blocks format**. Autocache was only handling prompts already in blocks format, so system strings were never cached regardless of size.

## Solution

This PR implements automatic conversion of system strings to the blocks format when they meet caching thresholds:

1. **Convert system strings to SystemBlocks** when content ≥ minimum tokens
2. **Add cache_control** to the converted blocks
3. **Custom JSON marshaling** to serialize SystemBlocks as `system` array
4. **Custom JSON unmarshaling** to accept both string and array formats

The fix is **backward compatible** - it handles both formats seamlessly.

## Changes

### Core Logic (`internal/cache/injector.go`)
- Modified `CollectCacheCandidates` to convert system strings to SystemBlocks when cacheable
- Removed obsolete string pointer handling in `applyCacheControlToContent`

### JSON Handling (`internal/types/models.go`)
- Added `MarshalJSON` to serialize SystemBlocks as `system` array
- Added `UnmarshalJSON` to deserialize both string and array formats
- Ensures requests with cache control serialize correctly to Anthropic API

### Tests
- Added `TestSystemStringConversionToBlocks` - verifies conversion logic
- Added `TestSystemStringBelowThreshold` - verifies small prompts aren't converted
- Added `TestAnthropicRequest_MarshalJSON_*` - tests JSON serialization
- Added `TestAnthropicRequest_UnmarshalJSON_*` - tests JSON deserialization
- Added `TestAnthropicRequest_RoundTrip` - tests marshal → unmarshal consistency
- Updated mock server to handle SystemBlocks format
- Updated existing tests to use SystemBlocks instead of string pointers

## Test Results

✅ **All 81 tests pass**

**End-to-end validation with real Anthropic API:**
```
First request (cache creation):
  cache_creation_input_tokens: 1201 ✅
  cache_read_input_tokens: 0

Second request (cache read):
  cache_creation_input_tokens: 0
  cache_read_input_tokens: 1201 ✅
```

## Before/After

**Before (broken):**
```json
{
  "usage": {
    "input_tokens": 476,
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 0
  }
}
```

**After (fixed with >1024 token prompt):**
```json
{
  "usage": {
    "input_tokens": 8,
    "cache_creation_input_tokens": 1201,
    "cache_read_input_tokens": 0
  }
}
```

## Breaking Changes

None. The change is fully backward compatible.

## For Issue Reporter

The fix addresses your exact scenario. However, note that your original test prompt (~476 tokens) is **below the 1024-token minimum** required for caching on Claude 3.5 Sonnet. You'll need a larger system prompt to see caching in action.

With a prompt >1024 tokens, caching now works correctly using the simple `system` string format.