### PR TITLE
Fix version information in binaries and health endpoint

### DIFF
--- a/cmd/autocache/main.go
+++ b/cmd/autocache/main.go
@@ -16,8 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// Version information
+var (
+	// Version information (set via ldflags during build)
 	Version   = "1.0.0"
 	BuildTime = "development"
 	GitCommit = "unknown"
@@ -41,7 +41,7 @@ func main() {
 	cfg.PrintConfig(logger)
 
 	// Create handler
-	handler := server.NewAutocacheHandler(cfg, logger)
+	handler := server.NewAutocacheHandler(cfg, logger, Version)
 
 	// Setup routes
 	mux := handler.SetupRoutes()

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -28,6 +28,7 @@ type AutocacheHandler struct {
 	proxyClient    *client.ProxyClient
 	config         *config.Config
 	logger         *logrus.Logger
+	version        string
 	requestHistory []types.CacheMetadata
 	historyMutex   sync.RWMutex
 	panicCount     atomic.Uint64
@@ -35,7 +36,7 @@ type AutocacheHandler struct {
 }
 
 // NewAutocacheHandler creates a new handler
-func NewAutocacheHandler(cfg *config.Config, logger *logrus.Logger) *AutocacheHandler {
+func NewAutocacheHandler(cfg *config.Config, logger *logrus.Logger, version string) *AutocacheHandler {
 	strategy := types.CacheStrategy(cfg.CacheStrategy)
 
 	return &AutocacheHandler{
@@ -43,6 +44,7 @@ func NewAutocacheHandler(cfg *config.Config, logger *logrus.Logger) *AutocacheHa
 		proxyClient:    client.NewProxyClient(cfg.AnthropicURL, logger),
 		config:         cfg,
 		logger:         logger,
+		version:        version,
 		requestHistory: make([]types.CacheMetadata, 0, cfg.SavingsHistorySize),
 	}
 }
@@ -349,7 +351,7 @@ func (ah *AutocacheHandler) HandleHealth(w http.ResponseWriter, r *http.Request)
 
 	health := map[string]interface{}{
 		"status":   "healthy",
-		"version":  "1.0.0",
+		"version":  ah.version,
 		"strategy": ah.config.CacheStrategy,
 	}
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -59,10 +59,18 @@ func createMockAnthropicServer() *httptest.Server {
 		hasCacheControl := false
 		cacheTokens := 0
 
-		// Check system message for cache control
+		// Check system message for cache control (string format)
 		if req.System != "" {
 			cacheTokens += 500 // Mock cached system tokens
 			hasCacheControl = true
+		}
+
+		// Check system blocks for cache control (array format)
+		for _, block := range req.SystemBlocks {
+			if block.CacheControl != nil {
+				cacheTokens += 500 // Mock cached system tokens
+				hasCacheControl = true
+			}
 		}
 
 		// Check tools for cache control

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -110,7 +110,7 @@ func TestNewAutocacheHandler(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 	if handler == nil {
 		t.Fatal("Expected handler to be created")
 	}
@@ -139,7 +139,7 @@ func TestHandleMessages(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	tests := []struct {
 		name           string
@@ -287,7 +287,7 @@ func TestHandleMessagesInvalidRequests(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	tests := []struct {
 		name         string
@@ -354,7 +354,7 @@ func TestHandleMessagesBypass(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	request := &types.AnthropicRequest{
 		Model:     "claude-3-5-sonnet-20241022",
@@ -427,7 +427,7 @@ func TestHandleHealth(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	req := httptest.NewRequest("GET", "/health", nil)
 	rr := httptest.NewRecorder()
@@ -461,7 +461,7 @@ func TestHandleMetrics(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	rr := httptest.NewRecorder()
@@ -507,7 +507,7 @@ func TestSetupRoutes(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 	mux := handler.SetupRoutes()
 
 	if mux == nil {
@@ -548,7 +548,7 @@ func TestLogMiddleware(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel) // Suppress logs during test
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Create a simple test handler
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -643,7 +643,7 @@ func TestWriteError(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	rr := httptest.NewRecorder()
 	handler.writeError(rr, http.StatusBadRequest, "Test error message")
@@ -681,7 +681,7 @@ func TestPanicRecoveryMiddleware(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel) // Suppress error logs during test
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	t.Run("Handler that panics", func(t *testing.T) {
 		// Create a handler that deliberately panics
@@ -763,7 +763,7 @@ func TestPanicRecoveryMetrics(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Check initial panic count
 	initialPanics := handler.panicCount.Load()
@@ -803,7 +803,7 @@ func TestPanicRecoveryInMetricsEndpoint(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Trigger a panic first
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -886,7 +886,7 @@ func TestPanicRecoveryLogging(t *testing.T) {
 	logger.SetOutput(&logOutput)
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Create a handler that panics
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/types/models_test.go
+++ b/internal/types/models_test.go
@@ -234,3 +234,266 @@ func TestMessageMarshalJSON_OutputsArray(t *testing.T) {
 		t.Errorf("Expected 1 content block in output, got %d", len(content))
 	}
 }
+
+// TestAnthropicRequest_MarshalJSON_SystemString tests that system string is preserved
+func TestAnthropicRequest_MarshalJSON_SystemString(t *testing.T) {
+	req := AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		System:    "You are a helpful assistant",
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Unmarshal to check structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// System should be a string
+	system, ok := result["system"].(string)
+	if !ok {
+		t.Errorf("Expected system to be a string, got %T", result["system"])
+	}
+
+	if system != "You are a helpful assistant" {
+		t.Errorf("Expected system text, got %s", system)
+	}
+}
+
+// TestAnthropicRequest_MarshalJSON_SystemBlocks tests that SystemBlocks are serialized as system array
+func TestAnthropicRequest_MarshalJSON_SystemBlocks(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		SystemBlocks: []ContentBlock{
+			{
+				Type: "text",
+				Text: "You are a helpful assistant",
+				CacheControl: &CacheControl{
+					Type: "ephemeral",
+					TTL:  "1h",
+				},
+			},
+		},
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Unmarshal to check structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// System should be an array (not a string)
+	systemArray, ok := result["system"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected system to be an array when SystemBlocks is set, got %T", result["system"])
+	}
+
+	if len(systemArray) != 1 {
+		t.Fatalf("Expected 1 system block, got %d", len(systemArray))
+	}
+
+	// Check the first block
+	block, ok := systemArray[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected system block to be an object, got %T", systemArray[0])
+	}
+
+	if block["type"] != "text" {
+		t.Errorf("Expected type 'text', got %v", block["type"])
+	}
+
+	if block["text"] != "You are a helpful assistant" {
+		t.Errorf("Expected text 'You are a helpful assistant', got %v", block["text"])
+	}
+
+	// Check cache_control exists
+	cacheControl, ok := block["cache_control"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected cache_control to exist, got %T", block["cache_control"])
+	}
+
+	if cacheControl["type"] != "ephemeral" {
+		t.Errorf("Expected cache_control type 'ephemeral', got %v", cacheControl["type"])
+	}
+
+	if cacheControl["ttl"] != "1h" {
+		t.Errorf("Expected cache_control ttl '1h', got %v", cacheControl["ttl"])
+	}
+}
+
+// TestAnthropicRequest_MarshalJSON_SystemBlocksPriority tests SystemBlocks takes priority over System
+func TestAnthropicRequest_MarshalJSON_SystemBlocksPriority(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		System:    "This should be ignored",
+		SystemBlocks: []ContentBlock{
+			{
+				Type: "text",
+				Text: "This should be used",
+			},
+		},
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	// Unmarshal to check structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+
+	// System should be an array (SystemBlocks takes priority)
+	systemArray, ok := result["system"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected system to be an array when SystemBlocks is set, got %T", result["system"])
+	}
+
+	block, ok := systemArray[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected system block to be an object, got %T", systemArray[0])
+	}
+
+	if block["text"] != "This should be used" {
+		t.Errorf("Expected SystemBlocks to take priority, got text: %v", block["text"])
+	}
+}
+
+// TestAnthropicRequest_UnmarshalJSON_SystemString tests unmarshaling system as string
+func TestAnthropicRequest_UnmarshalJSON_SystemString(t *testing.T) {
+	jsonData := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"max_tokens": 100,
+		"system": "You are a helpful assistant",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+	}`)
+
+	var req AnthropicRequest
+	err := json.Unmarshal(jsonData, &req)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if req.System != "You are a helpful assistant" {
+		t.Errorf("Expected System string, got %s", req.System)
+	}
+
+	if len(req.SystemBlocks) != 0 {
+		t.Error("SystemBlocks should be empty when system is a string")
+	}
+}
+
+// TestAnthropicRequest_UnmarshalJSON_SystemBlocks tests unmarshaling system as array
+func TestAnthropicRequest_UnmarshalJSON_SystemBlocks(t *testing.T) {
+	jsonData := []byte(`{
+		"model": "claude-3-5-sonnet-20241022",
+		"max_tokens": 100,
+		"system": [
+			{
+				"type": "text",
+				"text": "You are a helpful assistant",
+				"cache_control": {"type": "ephemeral", "ttl": "1h"}
+			}
+		],
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+	}`)
+
+	var req AnthropicRequest
+	err := json.Unmarshal(jsonData, &req)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	if req.System != "" {
+		t.Error("System string should be empty when system is an array")
+	}
+
+	if len(req.SystemBlocks) != 1 {
+		t.Fatalf("Expected 1 SystemBlock, got %d", len(req.SystemBlocks))
+	}
+
+	if req.SystemBlocks[0].Text != "You are a helpful assistant" {
+		t.Errorf("Expected text in SystemBlock, got %s", req.SystemBlocks[0].Text)
+	}
+
+	if req.SystemBlocks[0].CacheControl == nil {
+		t.Fatal("Expected cache_control in SystemBlock")
+	}
+
+	if req.SystemBlocks[0].CacheControl.Type != "ephemeral" {
+		t.Errorf("Expected cache_control type 'ephemeral', got %s", req.SystemBlocks[0].CacheControl.Type)
+	}
+}
+
+// TestAnthropicRequest_RoundTrip tests marshal -> unmarshal round trip
+func TestAnthropicRequest_RoundTrip(t *testing.T) {
+	original := &AnthropicRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		SystemBlocks: []ContentBlock{
+			{
+				Type: "text",
+				Text: "System prompt",
+				CacheControl: &CacheControl{
+					Type: "ephemeral",
+					TTL:  "1h",
+				},
+			},
+		},
+		Messages: []Message{
+			{Role: "user", Content: []ContentBlock{{Type: "text", Text: "Hello"}}},
+		},
+	}
+
+	// Marshal
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	// Unmarshal
+	var decoded AnthropicRequest
+	err = json.Unmarshal(data, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	// Verify
+	if len(decoded.SystemBlocks) != 1 {
+		t.Fatalf("Expected 1 SystemBlock after round trip, got %d", len(decoded.SystemBlocks))
+	}
+
+	if decoded.SystemBlocks[0].Text != "System prompt" {
+		t.Errorf("Text mismatch after round trip: got %s", decoded.SystemBlocks[0].Text)
+	}
+
+	if decoded.SystemBlocks[0].CacheControl == nil {
+		t.Fatal("CacheControl lost after round trip")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes version information not being set correctly in Docker images, binaries, and the health endpoint.

## Problem
1. Docker images and binaries always showed version `1.0.0` instead of the actual release version (e.g., `v1.0.2-rc1`)
2. The `/health` endpoint returned a hardcoded `"version": "1.0.0"` instead of the actual build version
3. The root cause was using `const` instead of `var` for version variables, preventing Go's `-ldflags` from overriding them at build time

## Changes
1. **cmd/autocache/main.go**:
   - Changed version constants from `const` to `var` to allow ldflags injection
   - Pass `Version` to `AutocacheHandler` constructor

2. **internal/server/handler.go**:
   - Added `version` field to `AutocacheHandler` struct
   - Updated `NewAutocacheHandler` to accept version parameter
   - Modified `HandleHealth` to return actual version from struct instead of hardcoded "1.0.0"

3. **internal/server/handler_test.go**:
   - Updated all test calls to `NewAutocacheHandler` to pass test version "1.0.0-test"

## Testing
- ✅ All existing tests pass
- ✅ Verified Docker build with custom `VERSION` build arg correctly sets version
- ✅ Verified binary build with `-ldflags -X main.Version=...` correctly sets version
- ✅ Confirmed `--version` flag shows correct version
- ✅ Confirmed startup logs show correct version
- ✅ Health endpoint will now return the actual build version

## Example
After this fix, when building with:
```bash
docker build --build-arg VERSION=v1.0.2-rc1 ...
```

The resulting image will show:
- `./autocache --version` → `autocache version v1.0.2-rc1 ...`
- Startup logs → `version=v1.0.2-rc1`
- `GET /health` → `{"version": "v1.0.2-rc1", ...}`

## Impact
This ensures that deployed instances correctly report their version, which is crucial for:
- Debugging and support
- Monitoring and observability  
- Verifying correct deployment versions in production