### PR TITLE
Fix version information in binaries and health endpoint

### DIFF
--- a/cmd/autocache/main.go
+++ b/cmd/autocache/main.go
@@ -16,8 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// Version information
+var (
+	// Version information (set via ldflags during build)
 	Version   = "1.0.0"
 	BuildTime = "development"
 	GitCommit = "unknown"
@@ -41,7 +41,7 @@ func main() {
 	cfg.PrintConfig(logger)
 
 	// Create handler
-	handler := server.NewAutocacheHandler(cfg, logger)
+	handler := server.NewAutocacheHandler(cfg, logger, Version)
 
 	// Setup routes
 	mux := handler.SetupRoutes()

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -28,6 +28,7 @@ type AutocacheHandler struct {
 	proxyClient    *client.ProxyClient
 	config         *config.Config
 	logger         *logrus.Logger
+	version        string
 	requestHistory []types.CacheMetadata
 	historyMutex   sync.RWMutex
 	panicCount     atomic.Uint64
@@ -35,7 +36,7 @@ type AutocacheHandler struct {
 }
 
 // NewAutocacheHandler creates a new handler
-func NewAutocacheHandler(cfg *config.Config, logger *logrus.Logger) *AutocacheHandler {
+func NewAutocacheHandler(cfg *config.Config, logger *logrus.Logger, version string) *AutocacheHandler {
 	strategy := types.CacheStrategy(cfg.CacheStrategy)
 
 	return &AutocacheHandler{
@@ -43,6 +44,7 @@ func NewAutocacheHandler(cfg *config.Config, logger *logrus.Logger) *AutocacheHa
 		proxyClient:    client.NewProxyClient(cfg.AnthropicURL, logger),
 		config:         cfg,
 		logger:         logger,
+		version:        version,
 		requestHistory: make([]types.CacheMetadata, 0, cfg.SavingsHistorySize),
 	}
 }
@@ -349,7 +351,7 @@ func (ah *AutocacheHandler) HandleHealth(w http.ResponseWriter, r *http.Request)
 
 	health := map[string]interface{}{
 		"status":   "healthy",
-		"version":  "1.0.0",
+		"version":  ah.version,
 		"strategy": ah.config.CacheStrategy,
 	}
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -102,7 +102,7 @@ func TestNewAutocacheHandler(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 	if handler == nil {
 		t.Fatal("Expected handler to be created")
 	}
@@ -131,7 +131,7 @@ func TestHandleMessages(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	tests := []struct {
 		name           string
@@ -279,7 +279,7 @@ func TestHandleMessagesInvalidRequests(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	tests := []struct {
 		name         string
@@ -346,7 +346,7 @@ func TestHandleMessagesBypass(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	request := &types.AnthropicRequest{
 		Model:     "claude-3-5-sonnet-20241022",
@@ -419,7 +419,7 @@ func TestHandleHealth(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	req := httptest.NewRequest("GET", "/health", nil)
 	rr := httptest.NewRecorder()
@@ -453,7 +453,7 @@ func TestHandleMetrics(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	rr := httptest.NewRecorder()
@@ -499,7 +499,7 @@ func TestSetupRoutes(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 	mux := handler.SetupRoutes()
 
 	if mux == nil {
@@ -540,7 +540,7 @@ func TestLogMiddleware(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel) // Suppress logs during test
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Create a simple test handler
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -635,7 +635,7 @@ func TestWriteError(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	rr := httptest.NewRecorder()
 	handler.writeError(rr, http.StatusBadRequest, "Test error message")
@@ -673,7 +673,7 @@ func TestPanicRecoveryMiddleware(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel) // Suppress error logs during test
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	t.Run("Handler that panics", func(t *testing.T) {
 		// Create a handler that deliberately panics
@@ -755,7 +755,7 @@ func TestPanicRecoveryMetrics(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Check initial panic count
 	initialPanics := handler.panicCount.Load()
@@ -795,7 +795,7 @@ func TestPanicRecoveryInMetricsEndpoint(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Trigger a panic first
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -878,7 +878,7 @@ func TestPanicRecoveryLogging(t *testing.T) {
 	logger.SetOutput(&logOutput)
 	logger.SetLevel(logrus.ErrorLevel)
 
-	handler := NewAutocacheHandler(cfg, logger)
+	handler := NewAutocacheHandler(cfg, logger, "1.0.0-test")
 
 	// Create a handler that panics
 	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Fixes version information not being set correctly in Docker images, binaries, and the health endpoint.

## Problem
1. Docker images and binaries always showed version `1.0.0` instead of the actual release version (e.g., `v1.0.2-rc1`)
2. The `/health` endpoint returned a hardcoded `"version": "1.0.0"` instead of the actual build version
3. The root cause was using `const` instead of `var` for version variables, preventing Go's `-ldflags` from overriding them at build time

## Changes
1. **cmd/autocache/main.go**:
   - Changed version constants from `const` to `var` to allow ldflags injection
   - Pass `Version` to `AutocacheHandler` constructor

2. **internal/server/handler.go**:
   - Added `version` field to `AutocacheHandler` struct
   - Updated `NewAutocacheHandler` to accept version parameter
   - Modified `HandleHealth` to return actual version from struct instead of hardcoded "1.0.0"

3. **internal/server/handler_test.go**:
   - Updated all test calls to `NewAutocacheHandler` to pass test version "1.0.0-test"

## Testing
- ✅ All existing tests pass
- ✅ Verified Docker build with custom `VERSION` build arg correctly sets version
- ✅ Verified binary build with `-ldflags -X main.Version=...` correctly sets version
- ✅ Confirmed `--version` flag shows correct version
- ✅ Confirmed startup logs show correct version
- ✅ Health endpoint will now return the actual build version

## Example
After this fix, when building with:
```bash
docker build --build-arg VERSION=v1.0.2-rc1 ...
```

The resulting image will show:
- `./autocache --version` → `autocache version v1.0.2-rc1 ...`
- Startup logs → `version=v1.0.2-rc1`
- `GET /health` → `{"version": "v1.0.2-rc1", ...}`

## Impact
This ensures that deployed instances correctly report their version, which is crucial for:
- Debugging and support
- Monitoring and observability  
- Verifying correct deployment versions in production