### PR TITLE
fix: implement real-time streaming with proper flushing

### DIFF
--- a/internal/client/anthropic.go
+++ b/internal/client/anthropic.go
@@ -150,14 +150,35 @@ func (pc *ProxyClient) ForwardStreamingRequest(req *types.AnthropicRequest, head
 		}
 	}
 
+	// Get flusher for real-time streaming - must be supported
+	flusher, ok := responseWriter.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("responseWriter does not support Flusher interface - real-time streaming not possible")
+	}
+
 	// Set status code
 	responseWriter.WriteHeader(resp.StatusCode)
 
-	// Stream the response
-	_, err = io.Copy(responseWriter, resp.Body)
-	if err != nil {
-		pc.logger.WithError(err).Error("Failed to stream response")
-		return fmt.Errorf("failed to stream response: %w", err)
+	// Stream the response with real-time flushing
+	// Use small buffer (512 bytes) to minimize latency for SSE events (typically 100-200 bytes each)
+	buf := make([]byte, 512)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			_, writeErr := responseWriter.Write(buf[:n])
+			if writeErr != nil {
+				pc.logger.WithError(writeErr).Error("Failed to write response chunk")
+				return fmt.Errorf("failed to write response: %w", writeErr)
+			}
+			flusher.Flush() // Flush immediately for real-time streaming
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			pc.logger.WithError(err).Error("Failed to read response stream")
+			return fmt.Errorf("failed to read response stream: %w", err)
+		}
 	}
 
 	return nil

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -602,6 +602,13 @@ func (rw *responseWrapper) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+// Flush implements http.Flusher interface for real-time streaming
+func (rw *responseWrapper) Flush() {
+	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 // getClientIP gets the client IP address from request
 func getClientIP(r *http.Request) string {
 	// Check X-Forwarded-For header


### PR DESCRIPTION
The streaming output seems correct but only appears together at the very last moment. I tried to use AI tools to find and modify this problem. 

Since I'm not familiar with go, I followed the ai's advice and used a streaming package size of 512b instead of the 100-200b officially used by Anthropic. You can modify it to a more suitable size.

流式输出看起来正确但是只有在最后的时刻才一起出现. 我试着用AI工具找到并修改了这个问题. 

因为我对go并不了解, 所以遵循ai的建议使用了并非Anthropic官方使用的100-200b而是512b的流式包大小. 你们可以修改成更合适的大小.

---


This project is extremely helpful. I have been facing this problem for a long time but don't have the appropriate ability to complete similar projects. Thank you all.

这个项目非常的有帮助, 我长期面临这个问题但是没有合适的能力来完成类似的项目, 感谢你们.
