### PR TITLE
Add PR Video workflow

### DIFF
--- a/.github/workflows/pr-video.yml
+++ b/.github/workflows/pr-video.yml
@@ -1,0 +1,15 @@
+name: PR Video
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  generate-video:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'generate-video'
+    steps:
+      - name: Generate PR Video
+        uses: jmrobles/prvideo@v1
+        with:
+          api-key: ${{ secrets.PRVIDEO_API_KEY }}

--- a/.github/workflows/pr-video.yml
+++ b/.github/workflows/pr-video.yml
@@ -8,6 +8,9 @@ jobs:
   generate-video:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'generate-video'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Generate PR Video
         uses: jmrobles/prvideo@v1


### PR DESCRIPTION
## Summary

- Add GitHub Action workflow to generate demo videos for PRs
- Triggered when a PR is labeled with `generate-video`
- Uses jmrobles/prvideo@v1 action

## Setup Required

Add `PRVIDEO_API_KEY` secret to the repository settings with the API key from prvideo.dev.

## Usage

Add the `generate-video` label to any PR to trigger video generation. A video explaining the changes will be generated and posted as a comment on the PR.