### PR TITLE
feat: Add claude-opus-4-5-20251101 model support

### DIFF
--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -94,6 +94,16 @@ func NewPricingCalculator() *PricingCalculator {
 			CacheRead:    1.50,  // 15.00 * 0.1
 		},
 
+		// Claude Opus 4.5
+		"claude-opus-4-5-20251101": {
+			ModelName:    "claude-opus-4-5-20251101",
+			InputTokens:  15.00,
+			OutputTokens: 75.00,
+			CacheWrite5m: 18.75, // 15.00 * 1.25
+			CacheWrite1h: 30.00, // 15.00 * 2.0
+			CacheRead:    1.50,  // 15.00 * 0.1
+		},
+
 		// Claude 3.5 Haiku
 		"claude-3-5-haiku-20241022": {
 			ModelName:    "claude-3-5-haiku-20241022",


### PR DESCRIPTION
## Summary
- Add pricing configuration for Claude Opus 4.5 (`claude-opus-4-5-20251101`) model
- Enables proper cost calculations and ROI metrics when using this model
- Uses same pricing as other Opus 4 models ($15/M input, $75/M output)

Closes #13

## Test plan
- [x] Pricing tests pass
- [x] Build succeeds
- [x] Model can be looked up without falling back to default Sonnet pricing